### PR TITLE
fix: add back support for imap4flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,9 @@ setup(
             'require = sifter.commands.require:CommandRequire',
             'set = sifter.commands.variables:CommandSet',
             'stop = sifter.commands.stop:CommandStop',
+            'imap4flags.setflag = sifter.commands.imap4flags:CommandSetFlag',
+            'imap4flags.removeflag = sifter.commands.imap4flags:CommandRemoveFlag',
+            'imap4flags.addflag = sifter.commands.imap4flags:CommandAddFlag',
             # sifter tests
             'address = sifter.tests.address:TestAddress',
             'body = sifter.tests.body:TestBody',

--- a/sifter/extensions/__init__.py
+++ b/sifter/extensions/__init__.py
@@ -61,28 +61,28 @@ class ExtensionRegistry():
     def get_comparator(cls, comparator: Union[Text, 'Tag']) -> Type['Comparator']:
         handler = cls.get('comparator', comparator)
         if not isinstance(handler, type) or not issubclass(handler, Comparator):
-            raise ValueError('Wrong Comparator Type!')
+            raise ValueError("Wrong Comparator Type `%s'" % comparator)
         return handler
 
     @classmethod
     def get_command(cls, commandname: Text) -> Type['Command']:
         handler = cls.get('command', commandname)
         if not isinstance(handler, type) or not issubclass(handler, Command):
-            raise ValueError('Wrong Command Type!')
+            raise ValueError("Wrong Command Type `%s'" % commandname)
         return handler
 
     @classmethod
     def get_test(cls, testname: Text) -> Type['Test']:
         handler = cls.get('test', testname)
         if not isinstance(handler, type) or not issubclass(handler, Test):
-            raise ValueError('Wrong Test Type!')
+            raise ValueError("Wrong Test Type `%s'" % testname)
         return handler
 
     @classmethod
     def get_notification_method(cls, methodname: Text) -> Type[NotificationMethod]:
         handler = cls.get('test', methodname)
         if not isinstance(handler, type) or not issubclass(handler, NotificationMethod):
-            raise ValueError('Wrong Notification Method Type!')
+            raise ValueError("Wrong Notification Method Type `%s'" % methodname)
         return handler
 
     @classmethod

--- a/tests/evaluation_9.rules
+++ b/tests/evaluation_9.rules
@@ -1,0 +1,11 @@
+require "imap4flags";
+
+if header :contains ["From"] ["coyote"] {
+        setflag "test-set";
+        addflag "test-add";
+        removeflag "test-remove";
+} elsif header :contains "Subject" "$$$" {
+        redirect "postmaster@example.com";
+} else {
+        redirect "field@example.com";
+}

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -29,6 +29,11 @@ def test_evaulation():
         ("evaluation_1.msg", "evaluation_6.rules", [('reject', 'I do not accept messages from this address.')]),
         ("evaluation_1.msg", "evaluation_7.rules", [('reject', 'I do not accept messages from/* this is\nnot a comment */this address.\n.\n')]),
         ("evaluation_1.msg", "evaluation_8.rules", [('keep', None)]),
+        ("evaluation_1.msg", "evaluation_9.rules", [('setflag', ['test-set']),
+                                                    ('addflag', ['test-add']),
+                                                    ('removeflag', ['test-remove']),
+                                                    ('keep', None),
+                                                    ('keep', None)]),
         ("evaluation_1.msg", "evaluation_ihave_reject.rules", [('reject', 'I do not accept messages from this address.')]),
     )
 


### PR DESCRIPTION
Add back the support for imap4flags, and also add a test for them.

During the course of investigating this error some of the error messages coming out of the extensions class didn't provide enough information, so i have added any context information i could into those too.